### PR TITLE
Allows for staggered login pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ While it's a little fiddly as most login forms wildy differ, you can use this sc
 
 To use the `auth_links` feature, you will need to inspect the login form using your web browser (right click and choose inspect), and find the type and name of the element for both the username and password field. Once you have found these, put them the copied `config.yaml`. See the `example_config.yaml` for an example of how to do this.
 
+There is also a `login_type` option to allow for you to cycle through webpages that have staggered login pages, such as Google Apps. this can be achieved by dding the key of `login_type` and the value of `staggered` in `config.yaml`.
+
 
 ## Usage
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -9,7 +9,7 @@ local:
 
 auth_links:
   - url: https://gmail.com
-    staggered_login: True
+    login_type: staggered
     username_element_type: type
     username_element_name: email
     username: <username>

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -8,18 +8,19 @@ local:
   - /path/to/image2
 
 auth_links:
-  - url: https://foo.bar.com/
-    username_element_type: name
-    username_element_name: username
+  - url: https://gmail.com
+    staggered_login: True
+    username_element_type: type
+    username_element_name: email
     username: <username>
-    password_element_type: name
+    password_element_type: type
     password_element_name: password
     password: <password>
   - url: https://bar.foo.com
-    username_element_type: id
+    username_element_type: name
     username_element_name: email
     username: <email_address>
-    password_element_type: password
+    password_element_type: name
     password_element_name: password
     password: <password>
 

--- a/screen.py
+++ b/screen.py
@@ -43,8 +43,6 @@ attempting to enter the credentials again.
 """
 
 def rotate_pages(browser):
-    get_browser()
-
     while True:
         try:
             if config["links"]:
@@ -127,4 +125,5 @@ def rotate_pages(browser):
             get_browser()
 
 if __name__ == '__main__':
+    get_browser()
     rotate_pages(browser)

--- a/screen.py
+++ b/screen.py
@@ -43,6 +43,8 @@ attempting to enter the credentials again.
 """
 
 def rotate_pages(browser):
+    get_browser()
+
     while True:
         try:
             if config["links"]:
@@ -77,11 +79,29 @@ def rotate_pages(browser):
                       password_element_name
                     )
 
+                    """
+                    This is to check if the login_type has been set and if not,
+                    then setting it to 'not_set'. Otherwise it'll throw a
+                    NoneType exception.
+                    """
+
+                    if page.get("login_type") is not None:
+                        login_type = page.get("login_type")
+                    else:
+                        login_type = "not_set"
+
                     try:
                         if browser.find_element_by_xpath(username_xpath):
-                            browser.find_element_by_xpath(username_xpath).send_keys(username)
-                            browser.find_element_by_xpath(password_xpath).send_keys(password)
-                            browser.find_element_by_xpath(password_xpath).send_keys(Keys.ENTER)
+                            if login_type.lower() == "staggered":
+                                browser.find_element_by_xpath(username_xpath).send_keys(username)
+                                browser.find_element_by_xpath(username_xpath).send_keys(Keys.ENTER)
+                                time.sleep(1)
+                                browser.find_element_by_xpath(password_xpath).send_keys(password)
+                                browser.find_element_by_xpath(password_xpath).send_keys(Keys.ENTER)
+                            else:
+                                browser.find_element_by_xpath(username_xpath).send_keys(username)
+                                browser.find_element_by_xpath(password_xpath).send_keys(password)
+                                browser.find_element_by_xpath(password_xpath).send_keys(Keys.ENTER)
                     except Exception:
                         pass
 
@@ -107,5 +127,4 @@ def rotate_pages(browser):
             get_browser()
 
 if __name__ == '__main__':
-    get_browser()
     rotate_pages(browser)

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ if [ ! -d $REPO_PATH ]; then
 fi
 
 # Installing required python packages
-if [ -f $REPO_PATH/requirements.txt ]
+if [ -f $REPO_PATH/requirements.txt ]; then
     echo "Installing python packages"
     pip install -r requirements.txt
 fi


### PR DESCRIPTION
Using the login_type option in the config.yaml, we can now log into webpages that are staggered e.g. enter username, click next, enter password, click next.